### PR TITLE
Update citation. Closes issue #2.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,11 +213,11 @@ Citation
 If you used this package, please cite it as follows:
 
 .. code:: bash
-    
-	    @misc{amirsina_torfi_2017_810392,
+
+	    @misc{amirsina_torfi_2017_840395,
 		author       = {Amirsina Torfi},
-		title        = {astorfi/speech_feature_extraction: SpeechPy},
-		month        = jun,
+		title        = {{SpeechPy: Speech recognition and feature extraction}},
+		month        = aug,
 		year         = 2017,
-		doi          = {10.5281/zenodo.810392},
-		url          = {https://doi.org/10.5281/zenodo.810392}}
+		doi          = {10.5281/zenodo.840395},
+		url          = {https://doi.org/10.5281/zenodo.840395}}


### PR DESCRIPTION
As per issue #2. The citation text content is from https://zenodo.org/record/840395/export/hx via https://zenodo.org/badge/latestdoi/87262342, which is the link of the button you mentioned in your comment on issue #2.