### PR TITLE
Handle small signal sizes better

### DIFF
--- a/speechpy/main.py
+++ b/speechpy/main.py
@@ -71,6 +71,8 @@ def mfcc(signal, sampling_frequency, frame_length=0.020, frame_stride=0.01,num_c
 
     feature, energy = mfe(signal, sampling_frequency=sampling_frequency, frame_length=frame_length, frame_stride=frame_stride,
              num_filters=num_filters, fft_length=fft_length, low_frequency=low_frequency, high_frequency=high_frequency)
+    if len(feature) == 0:
+        return np.empty((0, num_cepstral))
     feature = np.log(feature)
     feature = dct(feature, type=2, axis=-1, norm='ortho')[:, :num_cepstral]
 

--- a/speechpy/processing.py
+++ b/speechpy/processing.py
@@ -29,29 +29,24 @@ def stack_frames(sig, sampling_frequency, frame_length=0.020, frame_stride=0.020
     frame_sample_length = int(np.round(sampling_frequency * frame_length))  # Defined by the number of samples
     frame_stride = float(np.round(sampling_frequency * frame_stride))
 
-    # Check the feasibility of stacking
-    if length_signal <= frame_sample_length:
-        numframes = 1
+    # Zero padding is done for allocating space for the last frame.
+    if zero_padding:
+        # Calculation of number of frames
+        numframes = 1 + int(math.ceil((length_signal - frame_sample_length) / frame_stride))
+
+        # Zero padding
+        len_sig = int((numframes - 1) * frame_stride + frame_sample_length)
+        additive_zeros = np.zeros((len_sig - length_signal,))
+        signal = np.concatenate((sig, additive_zeros))
+
     else:
-        # Zero padding is done for allocating space for the last frame.
-        if zero_padding:
-            # Calculation of number of frames
-            numframes = 1 + int(math.ceil((length_signal - frame_sample_length) / frame_stride))
+        # No zero padding! The last frame which does not have enough
+        # samples(remaining samples <= frame_sample_length), will be dropped!
+        numframes = 1 + int(math.floor((length_signal - frame_sample_length) / frame_stride))
 
-            # Zero padding
-            len_sig = int((numframes - 1) * frame_stride + frame_sample_length)
-            additive_zeros = np.zeros((len_sig - length_signal,))
-            signal = np.concatenate((sig, additive_zeros))
-
-        else:
-            # No zero padding! The last frame which does not have enough
-            # samples(remaining samples <= frame_sample_length), will be dropped!
-            numframes = 1 + int(math.floor((length_signal - frame_sample_length) / frame_stride))
-
-            # new length
-            len_sig = int((numframes - 1) * frame_stride + frame_sample_length)
-            signal = sig[0:len_sig]
-
+        # new length
+        len_sig = int((numframes - 1) * frame_stride + frame_sample_length)
+        signal = sig[0:len_sig]
 
     # Getting the indices of all frames.
     indices = np.tile(np.arange(0, frame_sample_length), (numframes, 1)) + np.tile(


### PR DESCRIPTION
Currently, passing a signal size equal to or less than the frame length throws an exception. This changes it so that when a signal of the same length is given, it gives a result like normal, and when a signall smaller than that is given, it outputs an empty array of the correct dimensions.

With change:
```Python
import numpy as np
from speechpy.main import mfcc
mfcc(np.ones((999)), 1000, 1, 1, 2)  # array([], shape=(0, 2), dtype=float64)
mfcc(np.ones((1000)), 1000, 1, 1, 2)  # array([[ 6.23832463,  0.        ]])
mfcc(np.ones((1999)), 1000, 1, 1, 2)  # array([[ 6.23832463,  0.        ]])
mfcc(np.ones((2000)), 1000, 1, 1, 2)  # array([[ 6.23832463,  0.        ], [ 6.23832463,  0.        ]])
```

Before:
```Python
import numpy as np
from speechpy.main import mfcc
mfcc(np.ones((999)), 1000, 1, 1, 2)  # UnboundLocalError: local variable 'signal' referenced before assignment
mfcc(np.ones((1000)), 1000, 1, 1, 2)  # UnboundLocalError: local variable 'signal' referenced before assignment
mfcc(np.ones((1999)), 1000, 1, 1, 2)  # array([[ 6.23832463,  0.        ]])
mfcc(np.ones((2000)), 1000, 1, 1, 2)  # array([[ 6.23832463,  0.        ], [ 6.23832463,  0.        ]])
```