### PR TITLE
Speed improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(name='speechpy',
       install_requires=[
           'scipy',
           'numpy',
+          'backports.functools_lru_cache;python_version<"3.2"'
       ],
       zip_safe=False)

--- a/speechpy/feature.py
+++ b/speechpy/feature.py
@@ -3,8 +3,12 @@ from __future__ import division
 import numpy as np
 from . import processing
 from scipy.fftpack import dct
-from functools import lru_cache
 from . import functions
+
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
 
 
 @lru_cache()

--- a/speechpy/feature.py
+++ b/speechpy/feature.py
@@ -1,11 +1,13 @@
 from __future__ import division
+
 import numpy as np
 from . import processing
 from scipy.fftpack import dct
-import math
+from functools import lru_cache
 from . import functions
 
 
+@lru_cache()
 def filterbanks(num_filter, fftpoints, sampling_freq, low_freq=None, high_freq=None):
     """Compute the Mel-filterbanks. Each filter will be stored in one rows. The columns correspond to fft bins.
 

--- a/speechpy/processing.py
+++ b/speechpy/processing.py
@@ -1,4 +1,6 @@
 import decimal
+from functools import lru_cache
+
 import numpy as np
 import math
 
@@ -23,6 +25,14 @@ def preemphasis(signal, shift=1, cof=0.98):
     rolled_signal = np.roll(signal, shift)
     return signal - cof * rolled_signal
 
+
+@lru_cache()
+def _create_frame_indices(numframes, frame_stride, frame_sample_length):
+    indices = np.tile(np.arange(0, frame_sample_length), (numframes, 1)) + np.tile(
+        np.arange(0, numframes * frame_stride, frame_stride), (frame_sample_length, 1)).T
+    return np.array(indices, dtype=np.int32)
+
+
 def stack_frames(sig, sampling_frequency, frame_length=0.020, frame_stride=0.020, filter=lambda x: np.ones((x,)),
                  zero_padding=True):
     """Frame a signal into overlapping frames.
@@ -40,14 +50,13 @@ def stack_frames(sig, sampling_frequency, frame_length=0.020, frame_stride=0.020
             array: stacked_frames-Array of frames of size (number_of_frames x frame_len).
 
     """
-
     ## Check dimension
     assert sig.ndim == 1, "Signal dimention should be of the format of (N,) but it is %s instead" % str(sig.shape)
 
     # Initial necessary values
     length_signal = sig.shape[0]
-    frame_sample_length = int(np.round(sampling_frequency * frame_length))  # Defined by the number of samples
-    frame_stride = float(np.round(sampling_frequency * frame_stride))
+    frame_sample_length = int(sampling_frequency * frame_length + 0.5)  # Defined by the number of samples
+    frame_stride = float(int(sampling_frequency * frame_stride + 0.5))
 
     # Zero padding is done for allocating space for the last frame.
     if zero_padding:
@@ -69,9 +78,7 @@ def stack_frames(sig, sampling_frequency, frame_length=0.020, frame_stride=0.020
         signal = sig[0:len_sig]
 
     # Getting the indices of all frames.
-    indices = np.tile(np.arange(0, frame_sample_length), (numframes, 1)) + np.tile(
-        np.arange(0, numframes * frame_stride, frame_stride), (frame_sample_length, 1)).T
-    indices = np.array(indices, dtype=np.int32)
+    indices = _create_frame_indices(numframes, frame_stride, frame_sample_length)
 
     # Extracting the frames based on the allocated indices.
     frames = signal[indices]

--- a/speechpy/processing.py
+++ b/speechpy/processing.py
@@ -1,8 +1,12 @@
 import decimal
-from functools import lru_cache
 
 import numpy as np
 import math
+
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
 
 
 # 1.4 becomes 1 and 1.6 becomes 2. special case: 1.5 becomes 2.


### PR DESCRIPTION
 - Add function caching to speed up computation of functions called with
 the same parameters
 - Remove use of np.round since it's slower for primitives

From testing in my use case, I get the following speed increases relative to the given function:
### stack_frames()
 - **Removing np.round**: 20%
 - **Adding create_indices lru**: 60%

### mfcc()
 - **Adding lru to filterbank**: 310%