### PR TITLE
Fixed a small bug rarely causing type mismatch

### DIFF
--- a/speechpy/processing.py
+++ b/speechpy/processing.py
@@ -216,7 +216,7 @@ def derivative_extraction(feat, DeltaWindows):
     rows, cols = feat.shape
 
     # Difining the vector of differences.
-    DIF = np.zeros(feat.shape, dtype=float)
+    DIF = np.zeros(feat.shape, dtype=feat.dtype)
     Scale = 0
 
     # Pad only along features in the vector.


### PR DESCRIPTION
when you use the derivative_extraction function, you are likely to concatenate it with your features, and your features' type might be chosen carefully in a manner sensitive to memory usage.

for example in my project i have a large dataset (which is normal for the use case of this library) which i use float32 as the datatype of it's values, since it's accuracy is enough and it reduces the memory footprint by half compared to float64, but when i used the derivative_extraction it calculated it's values in float64 and when i concatenated the derivatives and the original features all the values where converted to float64 and the system's memory usage was doubled, which wasn't immediately apparent.

this is not that critical and it could be fixed by converting types from outside the library call, but why bother with the inconvenience when changing the datatype of the derivatives array from the incoming feature's datatype is not needed.