### PR TITLE
Fixed some bugs in mel filterbanks.

### DIFF
--- a/speechpy/feature.py
+++ b/speechpy/feature.py
@@ -44,7 +44,7 @@ def filterbanks(
         coefficients (int): (fftpoints//2 + 1). Default is 257.
         sampling_freq (float): the samplerate of the signal we are working
             with. It affects mel spacing.
-        low_freq (float): lowest band edge of mel filters, default 0 Hz
+        low_freq (float): lowest band edge of mel filters, default 300 Hz
         high_freq (float): highest band edge of mel filters,
             default samplerate/2
 
@@ -52,8 +52,10 @@ def filterbanks(
            array: A numpy array of size num_filter x (fftpoints//2 + 1)
                which are filterbank
     """
-    high_freq = high_freq or sampling_freq / 2
-    low_freq = low_freq or 300
+    if high_freq is None:
+        high_freq = sampling_freq / 2
+    if low_freq is None:
+        low_freq = 300
     s = "High frequency cannot be greater than half of the sampling frequency!"
     assert high_freq <= sampling_freq / 2, s
     assert low_freq >= 0, "low frequency cannot be less than zero!"

--- a/speechpy/feature.py
+++ b/speechpy/feature.py
@@ -74,9 +74,11 @@ def filterbanks(
     # The frequency resolution required to put filters at the
     # exact points calculated above should be extracted.
     #  So we should round those frequencies to the closest FFT bin.
+
+    fftpoints = (coefficients - 1) * 2
     freq_index = (
         np.floor(
-            (coefficients +
+            (fftpoints +
              1) *
             hertz /
             sampling_freq)).astype(int)


### PR DESCRIPTION
I wrote some code to compare the mel filterbanks in librosa, python speech feature and speechpy, and found two problems.
- 1. The initialization of the band edge of the Mel filterbanks may be wrong. 
- 2. The calculation to convert frequency to fft bin number is wrong.

```python
import matplotlib.pyplot as plt
import numpy as np
import librosa
import python_speech_features as psf
import speechpy

n_fft = 256        # The number of FFT components
n_filter = 20      # The number of filters in the filterbank
samplerate = 16000 # The samplerate of the signal
low_freq = 0       # The lowest band edge of the filters
high_freq = 8000   # The highest band edge of the filters

librosa_fbanks = librosa.filters.mel(
    sr=samplerate, n_fft=n_fft, n_mels=n_filter, fmin=low_freq, fmax=high_freq, norm=None)
print("Librosa mel fbanks shape:{}".format(librosa_fbanks.shape))

psf_fbanks = psf.base.get_filterbanks(
    nfilt=n_filter, nfft=n_fft, samplerate=samplerate, lowfreq=low_freq, highfreq=high_freq)
print("PSF mel fbanks shape:{}".format(psf_fbanks.shape))

coefficients = int(n_fft/2 + 1)
speechpy_fbanks = speechpy.feature.filterbanks(
    n_filter, coefficients, sampling_freq=samplerate, low_freq=low_freq, high_freq=high_freq)
print("Speechpy mel fbanks shape:{}".format(speechpy_fbanks.shape))

fig, axes = plt.subplots(nrows=3, ncols=1, figsize=(10, 10))

x = np.array(list(range(speechpy_fbanks.shape[1])))
x = x * (samplerate / (n_fft + 1))

for i in range(librosa_fbanks.shape[0]):
    axes[0].plot(x, librosa_fbanks[i])
axes[0].set_title("librosa mel fbanks")

for i in range(psf_fbanks.shape[0]):
    axes[1].plot(x, psf_fbanks[i])
axes[1].set_title("psf mel fbanks")

for i in range(speechpy_fbanks.shape[0]):
    axes[2].plot(x, speechpy_fbanks[i])
axes[2].set_title("speechpy mel fbanks")

plt.show()
```
![image](https://user-images.githubusercontent.com/28107329/140459904-43c69083-69da-4d69-a62b-e4c041eb5a25.png)

As shown in the figure, the parameter setting of **low_freq** of filterbanks of speechpy is invalid, and the filterbanks only covers half of the frequency band.

The first problem is caused by 
```python
low_freq = low_freq or 300.
``` 
When low_freq is 0, low_freq or 300 will return 300 instead of 0.

The second problem is a calculation error.
```python
freq_index = (
    np.floor(
        (coefficients +
         1) *
        hertz /
        sampling_freq)).astype(int)
```
**coefficients** is equal to fftpoints/2 +1, which cannot cover the complete frequency band. We should use fftpoints instead of coefficients for calculation.

**As shown in my code，I have fixed the above two bugs and hope to get your review and merge. Thank you!**